### PR TITLE
Fix styling bugs appearing on ultrawide monitors

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,7 +1,9 @@
 /* Background and Color Scheme */
 .bg-background {
   background-color: rgb(240, 240, 240);
-  min-height: calc(100vh - 56px);
+  /* The subtracted values account for the
+     height and padding of the `navbar`. */
+  min-height: calc(100vh - 60px - 24px);
 }
 
 .bg-empty {
@@ -111,6 +113,7 @@
 @media (min-width: 991.9px) {
     .nav-link {
       display: flex;
+      align-items: center;
       justify-content: center;
     }
 }

--- a/templates/modules/app/core.html
+++ b/templates/modules/app/core.html
@@ -1,7 +1,6 @@
 <div id="main-app-window-div" style="
   --widthMultiplier: 1;
-  height: calc( 100vh - 56px );
-  width: 100vw;
+  height: calc(100vh - 60px - 24px);
   overflow:hidden;
 ">
   <iframe


### PR DESCRIPTION
This should fix some styling issues on a ultrawide monitor (res: 3440x1440). Changing the resolution width via the Django admin didn't work.

![ultrawide-issu-before](https://user-images.githubusercontent.com/7025739/199747108-129a0d0d-fa13-45dc-bc5f-f01a7d2d0f8a.png)
