### PR TITLE
3.0.0 dev combobox multi examples

### DIFF
--- a/cave_api/cave_api/examples/general_props_all.py
+++ b/cave_api/cave_api/examples/general_props_all.py
@@ -205,6 +205,18 @@ def execute_command(session_data, socket, command="init", **kwargs):
                             },
                             "help": "Select an option from the combobox",
                         },
+                        "comboBoxMultiExample": {
+                            "name": "ComboBox Multi Example",
+                            "type": "selector",
+                            "variant": "comboboxMulti",
+                            "placeholder": "Select multiple options",
+                            "options": {
+                                "option_a": {"name": "Option A"},
+                                "option_b": {"name": "Option B"},
+                                "option_c": {"name": "Option C"},
+                            },
+                            "help": "Select multiple options from the combobox",
+                        },
                         "nestedItemExample": {
                             "name": "Nested Item Example",
                             "type": "selector",
@@ -265,6 +277,7 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "vstepperItemExample": ["option_c"],
                         "hradioItemExample": ["option_c"],
                         "comboBoxItemExample": ["option_b"],
+                        "comboBoxMultiExample": ["option_a", "option_b"],
                         "nestedItemExample": [
                             "t1_b1_tw1",
                             "t1_b1_tw2",
@@ -388,24 +401,30 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                 "type": "item",
                                 "column": 4,
                                 "row": 6,
-                                "itemId": "hstepperItemExample",
+                                "itemId": "comboBoxMultiExample",
                             },
                             "col4Row7": {
                                 "type": "item",
                                 "column": 4,
                                 "row": 7,
-                                "itemId": "vstepperItemExample",
+                                "itemId": "hstepperItemExample",
                             },
                             "col4Row8": {
                                 "type": "item",
                                 "column": 4,
                                 "row": 8,
-                                "itemId": "hradioItemExample",
+                                "itemId": "vstepperItemExample",
                             },
                             "col4Row9": {
                                 "type": "item",
                                 "column": 4,
                                 "row": 9,
+                                "itemId": "hradioItemExample",
+                            },
+                            "col4Row10": {
+                                "type": "item",
+                                "column": 4,
+                                "row": 10,
                                 "itemId": "nestedItemExample",
                             },
                             "col5Row1": {

--- a/cave_api/cave_api/examples/kitchen_sink.py
+++ b/cave_api/cave_api/examples/kitchen_sink.py
@@ -399,6 +399,18 @@ def execute_command(session_data, socket, command="init", **kwargs):
                             "enabled": True,
                             "help": "Select an option from the combobox",
                         },
+                        "comboBoxMultiExample": {
+                            "name": "ComboBox Multi Example",
+                            "type": "selector",
+                            "variant": "comboboxMulti",
+                            "placeholder": "Select multiple options",
+                            "options": {
+                                "option_a": {"name": "Option A"},
+                                "option_b": {"name": "Option B"},
+                                "option_c": {"name": "Option C"},
+                            },
+                            "help": "Select multiple options from the combobox",
+                        },
                         "nestedItemExample": {
                             "name": "Nested Item Example",
                             "type": "selector",
@@ -488,6 +500,7 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "vstepperItemExample": ["option_c"],
                         "hradioItemExample": ["option_c"],
                         "comboBoxItemExample": ["option_b"],
+                        "comboBoxMultiExample": ["option_a", "option_b"],
                         "nestedItemExample": [
                             "t1_b1_tw1",
                             "t1_b1_tw2",
@@ -613,24 +626,30 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                 "type": "item",
                                 "column": 4,
                                 "row": 6,
-                                "itemId": "hstepperItemExample",
+                                "itemId": "comboBoxMultiExample",
                             },
                             "col4Row7": {
                                 "type": "item",
                                 "column": 4,
                                 "row": 7,
-                                "itemId": "vstepperItemExample",
+                                "itemId": "hstepperItemExample",
                             },
                             "col4Row8": {
                                 "type": "item",
                                 "column": 4,
                                 "row": 8,
-                                "itemId": "hradioItemExample",
+                                "itemId": "vstepperItemExample",
                             },
                             "col4Row9": {
                                 "type": "item",
                                 "column": 4,
                                 "row": 9,
+                                "itemId": "hradioItemExample",
+                            },
+                            "col4Row10": {
+                                "type": "item",
+                                "column": 4,
+                                "row": 10,
                                 "itemId": "nestedItemExample",
                             },
                             "col5Row1": {


### PR DESCRIPTION
Added `comboboxMulti` prop example to `cave_api/cave_api/examples/general_props_all.py` and `cave_api/cave_api/examples/kitchen_sink.py`.

![image](https://github.com/user-attachments/assets/7c6da65b-bd52-4234-8809-6f514a56c880)
