### PR TITLE
Remove need to use cache functions.

### DIFF
--- a/cave_core/management/commands/clearcache.py
+++ b/cave_core/management/commands/clearcache.py
@@ -9,6 +9,6 @@ class Command(BaseCommand):
         self.stdout.write("Clearing the Cache (memory and persistent)...")
         try:
             cache = Cache()
-            cache.delete_pattern("*")
+            cache.clear()
         except Exception as e:
             raise CommandError(f"Failed to clear the cache with the following error: {e}")

--- a/example.env
+++ b/example.env
@@ -52,6 +52,8 @@ DATABASE_IMAGE='postgres:17'
 REDIS_IMAGE='redis:7'
 
 # Optional Variables for Cache Backup Persistence
+# Note: These features are only availabe in Valkey and Redis instances that support the `keys()` command
+# Note: Most scalable or serverless redis and valkey caches do not support the keys command
 # Uncomment to enable
 # # Specify the interval for backing up the cache in seconds (Recommended: 15 minutes)
 # CACHE_BACKUP_INTERVAL=900

--- a/templates/modules/base/authenticated_nav_pages.html
+++ b/templates/modules/base/authenticated_nav_pages.html
@@ -1,6 +1,6 @@
   <ul class="navbar-nav mr-auto">
     <li class="nav-item">
-      <a class="nav-link {{home_active}}" href="/app">
+      <a class="nav-link {{home_active}}" href="/app/">
         <span class="material-icons">home</span>
         <p class="d-inline d-lg-none mx-3">Home</p>
       </a>


### PR DESCRIPTION
Remove need to use cache functions (keys, set_many, delete_many) as they are not often supported by scalable / serverless caches.

These functions are still called if static cache backups are enabled, but otherwise are not needed.

Notes for limitations have been added in appropriate places.