### PR TITLE
Remove showToolbar and prettify example files

### DIFF
--- a/cave_api/cave_api/examples/data_external_example.py
+++ b/cave_api/cave_api/examples/data_external_example.py
@@ -33,7 +33,9 @@ def execute_command(session_data, socket, command="init", **kwargs):
             )
         except requests.RequestException as e:
             # If an exception is raised, notify the user that the population data was not fetched
-            socket.notify("Unable to fetch population data.", title="Error", theme="error")
+            socket.notify(
+                "Unable to fetch population data.", title="Error", theme="error"
+            )
             population_data = {}
 
         # Define a dictionary of state codes to state names
@@ -217,7 +219,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                             "map": {
                                 "type": "map",
                                 "mapId": "populationMap",
-                                "showToolbar": False,
                                 "maximized": True,
                             },
                         },

--- a/cave_api/cave_api/examples/kitchen_sink.py
+++ b/cave_api/cave_api/examples/kitchen_sink.py
@@ -126,7 +126,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                 "precision": 4,
                 "trailingZeros": True,
                 "unitPlacement": "afterWithSpace",
-                "showToolbar": True,
             },
         },
         "appBar": {
@@ -728,7 +727,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "map1": {
                             "type": "map",
                             "mapId": "map1",
-                            "showToolbar": False,
                             "maximized": True,
                         },
                         "statBar": {

--- a/cave_api/cave_api/examples/map.py
+++ b/cave_api/cave_api/examples/map.py
@@ -55,7 +55,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "map": {
                             "type": "map",
                             "mapId": "exampleMap",
-                            "showToolbar": False,
                             "maximized": True,
                         },
                     },

--- a/cave_api/cave_api/examples/map_arcs.py
+++ b/cave_api/cave_api/examples/map_arcs.py
@@ -92,8 +92,16 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                 "notation": "precision",
                                 "precision": 0,
                                 "data": [
-                                    {"value": "min", "size": "5px", "color": "rgb(233 0 0)"},
-                                    {"value": "max", "size": "10px", "color": "rgb(96 2 2)"},
+                                    {
+                                        "value": "min",
+                                        "size": "5px",
+                                        "color": "rgb(233 0 0)",
+                                    },
+                                    {
+                                        "value": "max",
+                                        "size": "10px",
+                                        "color": "rgb(96 2 2)",
+                                    },
                                 ],
                             },
                         },
@@ -135,8 +143,16 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                 "notation": "precision",
                                 "precision": 0,
                                 "data": [
-                                    {"value": 0, "size": "5px", "color": "rgb(233 0 0)"},
-                                    {"value": 105, "size": "10px", "color": "rgb(96 2 2)"},
+                                    {
+                                        "value": 0,
+                                        "size": "5px",
+                                        "color": "rgb(233 0 0)",
+                                    },
+                                    {
+                                        "value": 105,
+                                        "size": "10px",
+                                        "color": "rgb(96 2 2)",
+                                    },
                                 ],
                             },
                         },
@@ -184,7 +200,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "map": {
                             "type": "map",
                             "mapId": "exampleMap",
-                            "showToolbar": False,
                             "maximized": True,
                         },
                     },

--- a/cave_api/cave_api/examples/map_customized.py
+++ b/cave_api/cave_api/examples/map_customized.py
@@ -107,7 +107,9 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                 "type": "raster",
                                 # EG: See a list of raster sources based on OSM here:
                                 # https://wiki.openstreetmap.org/wiki/Raster_tile_providers
-                                "tiles": ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+                                "tiles": [
+                                    "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+                                ],
                                 "tileSize": 256,
                                 "attribution": "Map tiles by <a target='_top' rel='noopener' href='https://osmfoundation.org/'>OpenStreetMap</a>, under <a target='_top' rel='noopener' href='https://osmfoundation.org/copyright'>Open Database License</a>.",
                             },
@@ -155,7 +157,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "map": {
                             "type": "map",
                             "mapId": "exampleMap",
-                            "showToolbar": False,
                             "maximized": True,
                         },
                     },

--- a/cave_api/cave_api/examples/map_geos.py
+++ b/cave_api/cave_api/examples/map_geos.py
@@ -57,7 +57,10 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                     "value": True,
                                     "icon": "pi/PiMountains",
                                     "colorBy": "isTargetArea",
-                                    "colorByOptions": ["customerSentiment", "isTargetArea"],
+                                    "colorByOptions": [
+                                        "customerSentiment",
+                                        "isTargetArea",
+                                    ],
                                 },
                             },
                         },
@@ -161,7 +164,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "map": {
                             "type": "map",
                             "mapId": "exampleMap",
-                            "showToolbar": False,
                             "maximized": True,
                         },
                     },

--- a/cave_api/cave_api/examples/map_nodes.py
+++ b/cave_api/cave_api/examples/map_nodes.py
@@ -86,8 +86,16 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                 "notation": "precision",
                                 "precision": 0,
                                 "data": [
-                                    {"value": "min", "size": "30px", "color": "rgb(233 0 0)"},
-                                    {"value": "max", "size": "45px", "color": "rgb(96 2 2)"},
+                                    {
+                                        "value": "min",
+                                        "size": "30px",
+                                        "color": "rgb(233 0 0)",
+                                    },
+                                    {
+                                        "value": "max",
+                                        "size": "45px",
+                                        "color": "rgb(96 2 2)",
+                                    },
                                 ],
                             },
                         },
@@ -124,7 +132,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "map": {
                             "type": "map",
                             "mapId": "exampleMap",
-                            "showToolbar": False,
                             "maximized": True,
                         },
                     },

--- a/cave_api/cave_api/examples/other_examples/future/map_feature_all_3D.py
+++ b/cave_api/cave_api/examples/other_examples/future/map_feature_all_3D.py
@@ -122,8 +122,16 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                 "notation": "precision",
                                 "precision": 0,
                                 "data": [
-                                    {"value": "min", "size": "30px", "color": "rgb(233 0 0)"},
-                                    {"value": "max", "size": "45px", "color": "rgb(96 2 2)"},
+                                    {
+                                        "value": "min",
+                                        "size": "30px",
+                                        "color": "rgb(233 0 0)",
+                                    },
+                                    {
+                                        "value": "max",
+                                        "size": "45px",
+                                        "color": "rgb(96 2 2)",
+                                    },
                                 ],
                             },
                         },
@@ -165,8 +173,16 @@ def execute_command(session_data, socket, command="init", **kwargs):
                             "help": "Demand for this state",
                             "gradient": {
                                 "data": [
-                                    {"value": "min", "color": "rgb(233 0 0)", "height": "10px"},
-                                    {"value": "max", "color": "rgb(96 2 2)", "height": "40px"},
+                                    {
+                                        "value": "min",
+                                        "color": "rgb(233 0 0)",
+                                        "height": "10px",
+                                    },
+                                    {
+                                        "value": "max",
+                                        "color": "rgb(96 2 2)",
+                                        "height": "40px",
+                                    },
                                 ],
                             },
                         },
@@ -317,7 +333,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "map": {
                             "type": "map",
                             "mapId": "exampleMap",
-                            "showToolbar": False,
                             "maximized": True,
                         },
                     },

--- a/cave_api/cave_api/examples/other_examples/map_feature_local_geojson/map_feature_local_geojson.py
+++ b/cave_api/cave_api/examples/other_examples/map_feature_local_geojson/map_feature_local_geojson.py
@@ -105,8 +105,16 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                 "notation": "precision",
                                 "precision": 0,
                                 "data": [
-                                    {"value": "min", "size": "5px", "color": "rgb(233 0 0)"},
-                                    {"value": "max", "size": "10px", "color": "rgb(96 2 2)"},
+                                    {
+                                        "value": "min",
+                                        "size": "5px",
+                                        "color": "rgb(233 0 0)",
+                                    },
+                                    {
+                                        "value": "max",
+                                        "size": "10px",
+                                        "color": "rgb(96 2 2)",
+                                    },
                                 ],
                             },
                         },
@@ -146,7 +154,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "map": {
                             "type": "map",
                             "mapId": "exampleMap",
-                            "showToolbar": False,
                             "maximized": True,
                         },
                     },

--- a/cave_api/cave_api/examples/other_examples/map_many_nodes.py
+++ b/cave_api/cave_api/examples/other_examples/map_many_nodes.py
@@ -86,8 +86,16 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                 "notation": "precision",
                                 "precision": 0,
                                 "data": [
-                                    {"value": "min", "size": "4px", "color": "rgb(233 0 0)"},
-                                    {"value": "max", "size": "6px", "color": "rgb(96 2 2)"},
+                                    {
+                                        "value": "min",
+                                        "size": "4px",
+                                        "color": "rgb(233 0 0)",
+                                    },
+                                    {
+                                        "value": "max",
+                                        "size": "6px",
+                                        "color": "rgb(96 2 2)",
+                                    },
                                 ],
                             },
                         },
@@ -110,7 +118,8 @@ def execute_command(session_data, socket, command="init", **kwargs):
                             "capacity": [100 + i for i in range(90**2)],
                             "includesAutomation": [i % 2 == 0 for i in range(90**2)],
                             "scenario": [
-                                "Scenario 1" if i % 2 == 0 else "Scenario 2" for i in range(90**2)
+                                "Scenario 1" if i % 2 == 0 else "Scenario 2"
+                                for i in range(90**2)
                             ],
                         },
                     },
@@ -126,7 +135,6 @@ def execute_command(session_data, socket, command="init", **kwargs):
                         "map": {
                             "type": "map",
                             "mapId": "exampleMap",
-                            "showToolbar": False,
                             "maximized": True,
                         },
                     },


### PR DESCRIPTION
Clean up examples since [#608](https://github.com/MIT-CAVE/cave_static/issues/608) removed `showToolbar`.