### PR TITLE
Migrate from one single development markdown to a skills based approach

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../docs/skills/

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,8 @@
       "Write(./cave_core/**)",
       "Read(./README.md)",
       "Edit(./README.md)",
-      "Write(./README.md)"
+      "Write(./README.md)",
+      "Bash(cave *)"
     ],
     "deny": [
       "Read(.env)",

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../docs/skills/

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -1,1 +1,0 @@
-../docs/DEVELOPMENT.md

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,9 +1,0 @@
-{
-    "$schema": "https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json",
-    "general": {
-        "defaultApprovalMode": "auto_edit"
-    },
-    "tools": {
-        "allowed": []
-    }
-}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,316 +20,58 @@ Only escalate to server-level changes if the request is clearly about:
 - WebSocket session infrastructure
 - Static files, templates, or deployment
 
-If in doubt, it is an API change.
+If in doubt, it is an API change. For the concrete implementation workflow, see the [add-feature](.claude/skills/add-feature/SKILL.md) skill.
+
+
+---
+
+## Skills
+
+| Skill | Use when |
+|---|---|
+| [run](.claude/skills/run/SKILL.md) | Launching the app with `cave run` and verifying it's actually serving in the browser |
+| [add-feature](.claude/skills/add-feature/SKILL.md) | Implementing a new API feature — buttons, charts, maps, sliders, panes |
+| [examples](.claude/skills/examples/SKILL.md) | Picking the closest reference example in `cave_api/examples/` before writing new API code |
+| [api-reference](.claude/skills/api-reference/SKILL.md) | Looking up `execute_command`, `session_data` keys, props schema, or field-level API docs |
+| [test](.claude/skills/test/SKILL.md) | Running the test suite via the `cave` CLI (`cave test <file>`) |
+| [add-test](.claude/skills/add-test/SKILL.md) | Adding a test for a custom command, or a replay/mutation-log regression test |
+| [lint](.claude/skills/lint/SKILL.md) | Formatting `cave_api/`, `cave_app/`, `cave_core/` with `cave prettify` |
+| [debug](.claude/skills/debug/SKILL.md) | Diagnosing validation errors, blank screens, or unexpected session state |
+| [cave-cli](.claude/skills/cave-cli/SKILL.md) | Running, resetting, upgrading, or otherwise managing the app's Docker environment via the `cave` CLI |
+| [release](.claude/skills/release/SKILL.md) | Owner-only — explains why to stop and flag instead of executing a release |
+
+
+---
+
+## The `cave` CLI
+
+This app runs in Docker, managed entirely through the `cave` CLI. See the [cave-cli](.claude/skills/cave-cli/SKILL.md) skill for the full command reference — including which commands are destructive and require user confirmation before running.
 
 ---
 ## Testing
 
-After making changes, you will often want to run a test to validate your work.
-
-Tests live in `cave_api/tests/`. Do not try to run them directly with python. You can only run them using the cave CLI. 
-
-```
-cave test <test_file.py>
-```
-
-### Default Available test files
-
-| File | Purpose | When to run |
-|---|---|---|
-| `init.py` | Calls `execute_command` with `command="init"` and validates the output. **Your primary test.** | After any API change |
-| `examples.py` | Runs `init` on every bundled example and validates each. | After touching any file in `examples/` |
-| `django.py` | Checks DB state (users, personal teams). Server-layer only. | After Django model or auth changes |
-| `replay.py` | Replays a recorded mutation log and validates the resulting session state. | After capturing a mutation log or to regression-test a recorded session |
-
-### Running tests
-
-```
-cave test init.py          # validate your app's init command (most common)
-cave test examples.py      # validate all bundled examples
-cave test django.py        # server-layer DB check
-cave test replay.py        # replay a mutation log and validate session state
-```
-
-### Standard pattern
-
-`init.py` ships configured to match whatever you are seeing in your live application.
-
-```python
-from cave_api.api import execute_command
-from cave_utils import Socket, Validator
-
-def test_init():
-    init_session_data = execute_command(session_data={}, socket=Socket(), command="init")
-
-    validator = Validator(init_session_data, ignore_keys=["meta"])
-    validator.log.print_logs()
-    assert len(validator.log.log) == 0
-
-if __name__ == "__main__":
-    test_init()
-```
-
-### Testing additional commands
-
-If your app has commands beyond `init`, test them by chaining calls:
-
-```python
-from cave_api.api import execute_command
-from cave_utils import Socket, Validator
-
-def test_command_chain():
-    init_session_data = execute_command(session_data={}, socket=Socket(), command="init")
-    my_command_session_data = execute_command(session_data=init_session_data, socket=Socket(), command="my_command")
-
-    validator = Validator(my_command_session_data, ignore_keys=["meta"])
-    validator.log.print_logs()
-    assert len(validator.log.log) == 0
-
-if __name__ == "__main__":
-    test_command_chain()
-```
-
-Create a new file (e.g., `cave_api/tests/test_my_command.py`) for command-specific tests. Run it with `cave test test_my_command.py`.
-
-### Replay testing
-
-`cave_api/tests/replay.py` replays a recorded mutation log through `execute_command` and validates the final session state. This is useful for reproducing bugs and regression-testing a specific user session.
-
-**Mutation logs** are CSV or JSON files captured from a live session. Place them in `cave_api/tests/mutation_logs/`. The bundled example is `MutationLogExample.csv`.
-
-`cave_api/tests/replay.py` ships with two helpers:
-
-- `test_replay(log_file)` — replays a single log file and validates the result. Edit this function to add path assertions specific to your app.
-- `test_all_logs()` — runs `test_replay` for every file in `mutation_logs/`.
-
-The underlying utility is `Replay` from `cave_api.utils.replay`:
-
-```python
-from cave_api.utils.replay import Replay
-
-replay = Replay("cave_api/tests/mutation_logs/MutationLogExample.csv")
-replay.advance("all")                        # replay every event
-replay.validate()                            # validate final state
-value = replay.get_path(["settings", "iconUrl"])  # inspect a specific path
-```
-
-Key `advance()` options:
-
-| Option | Default | What it does |
-|---|---|---|
-| `num_steps` | `1` | Steps to advance, or `"all"` for every remaining event |
-| `validate_each_step` | `False` | Validate after every event — slower, but pinpoints the exact failing event |
-| `validate_on_completion` | `True` | Validate once after all steps complete |
+Tests live in `tests/` and run only through the `cave` CLI (`cave test <file>`) — never directly with `python`. See the [test](.claude/skills/test/SKILL.md) skill for available test files and commands, and [add-test](.claude/skills/add-test/SKILL.md) for writing new command tests or replay-based regression tests.
 
 ---
 
-## The API: One Function
+## API Reference
 
-The entire CAVE API is a single Python function:
-
-```python
-def execute_command(session_data, socket, command="init", **kwargs):
-    ...
-    return session_data
-```
-
-| Parameter | Description |
-|---|---|
-| `session_data` | A plain dict representing the full app state. The frontend renders whatever is in here. |
-| `socket` | Sends notifications (`socket.notify("msg")`) or file exports (`socket.export("data:...")`) to the user. |
-| `command` | A string identifying what action to perform. Defaults to `"init"` on first load. |
-
-`execute_command` receives the current state, modifies it, and returns it. The framework handles routing, WebSockets, and rendering automatically.
-
-**Always handle `"init"`** — it runs on session start and must return the full initial state.
-
-**Standard command routing pattern:**
-```python
-def execute_command(session_data, socket, command="init", **kwargs):
-    if command == "init" or command == "reset":
-        return build_initial_state()
-    elif command == "run_model":
-        return update_state(session_data)
-    raise Exception(f"Command '{command}' not implemented")
-```
+The CAVE API is a single function, `execute_command(session_data, socket, command="init", **kwargs)`, that receives and returns a `session_data` dict built from 10 top-level keys (`settings`, `panes`, `mapFeatures`, `maps`, `groupedOutputs`, ...) and `props` (the shared schema behind every slider, dropdown, and map feature). Full details — the `execute_command` signature, the session_data key table, the props schema, and how to navigate the field-level docs in `docs/cave_api_docs/` — are in the [api-reference](.claude/skills/api-reference/SKILL.md) skill. Read it before building or modifying any panes, map features, or session_data structure.
 
 ---
 
-## Session Data: 10 Top-Level Keys
+## Entry Point & Custom Code
 
-`session_data` is a plain dict. The top-level keys control every part of what the user sees. All are optional except `settings`.
+`cave_api/api.py` is the hardcoded entry point — it must define or import `execute_command`. Three options are pre-configured (comment/uncomment to switch):
 
-| Key | Purpose | Doc file |
-|---|---|---|
-| `settings` | App-wide settings (icon URL, sync, etc.). **Required.** | `cave_api_docs/cave_utils_api_settings.txt` |
-| `appBar` | Buttons and pane-launchers in the app bar | `cave_api_docs/cave_utils_api_appBar.txt` |
-| `pages` | Static info pages | `cave_api_docs/cave_utils_api_pages.txt` |
-| `panes` | Slide-out panels with input props (sliders, dropdowns, etc.) | `cave_api_docs/cave_utils_api_panes.txt` |
-| `maps` | Map views with viewport, projection, layers | `cave_api_docs/cave_utils_api_maps.txt` |
-| `mapFeatures` | Interactive items on maps (nodes, arcs, geos) | `cave_api_docs/cave_utils_api_mapFeatures.txt` |
-| `groupedOutputs` | Hierarchical chart/table data with grouping | `cave_api_docs/cave_utils_api_groupedOutputs.txt` |
-| `globalOutputs` | App-wide KPI values | `cave_api_docs/cave_utils_api_globalOutputs.txt` |
-| `draggables` | Draggable UI overlay elements | `cave_api_docs/cave_utils_api_draggables.txt` |
-| `extraKwargs` | Special server-level flags (e.g. `wipeExisting`) | `cave_api_docs/cave_utils_api_extraKwargs.txt` |
-
-**Minimum valid app:**
-```python
-return {
-    "settings": {
-        "iconUrl": "https://react-icons.mitcave.com/5.4.0"
-    }
-}
-```
-
----
-
-## Props: The Building Blocks for Panes and Map Features
-
-**Props** are UI component definitions. They appear in two places:
-
-- **Panes** — interactive controls (sliders, dropdowns, buttons, etc.) that users manipulate to drive your app
-- **Map features** — visualization schemas that control how nodes, arcs, and geos are colored, sized, and labeled
-
-Every prop is a dictionary with a `name` and a `type`. Everything else is optional.
-
-```python
-{
-    "my_slider": {
-        "name": "My Slider",
-        "type": "num",
-        "variant": "slider",
-        "minValue": 0,
-        "maxValue": 100,
-        "unit": "%",
-        "apiCommand": "run_model",   # fires execute_command with command="run_model"
-        "apiCommandKeys": ["panes"],  # only pass these session_data keys
-    }
-}
-```
-
-### Prop Types
-
-| Type | What it renders | Common variants |
-|---|---|---|
-| `"head"` | Section header / divider | `"column"`, `"row"`, `"icon"` |
-| `"num"` | Numeric input | `"field"`, `"slider"`, `"icon"`, `"incslider"` |
-| `"toggle"` | Boolean switch | — |
-| `"text"` | Text input | `"single"`, `"textarea"` |
-| `"selector"` | Selection control | `"dropdown"`, `"radio"`, `"checkbox"`, `"combobox"`, `"comboboxMulti"`, `"nested"` |
-| `"button"` | Clickable button (can fire `apiCommand`) | — |
-| `"date"` | Date/time picker | `"date"`, `"time"`, `"datetime"` |
-| `"media"` | Image or video display | `"picture"`, `"video"` |
-
-### Props in Panes
-
-Panes pair a `props` schema with a `values` dict. The keys must match.
-
-```python
-"panes": {
-    "data": {
-        "my_pane": {
-            "name": "Controls",
-            "props": {
-                "speed": {"name": "Speed", "type": "num", "variant": "slider", "minValue": 0, "maxValue": 10}
-            },
-            "values": {
-                "speed": 5   # current value, keyed by prop name
-            },
-            "layout": {"type": "grid", "numColumns": 1, "numRows": "auto"}
-        }
-    }
-}
-```
-
-### Props in Map Features (Nodes, Arcs, Geos)
-
-Map features use the same `props` schema, but values live in `data.valueLists` alongside location data.
-
-```python
-"mapFeatures": {
-    "data": {
-        "my_nodes": {
-            "type": "node",
-            "name": "Facilities",
-            "props": {
-                "capacity": {"name": "Capacity", "type": "num", "variant": "icon"}
-            },
-            "data": {
-                "location": {
-                    "latitude": [[42.3], [41.8]],   # one list per feature
-                    "longitude": [[-71.0], [-87.6]]
-                },
-                "valueLists": {
-                    "capacity": [500, 1200]           # one value per feature
-                }
-            }
-        }
-    }
-}
-```
-
-**Key distinction:**
-
-| | Panes | Map Features |
-|---|---|---|
-| Values key | `values` (flat dict, one value per prop) | `data.valueLists` (list of values, one per feature) |
-| Location | N/A | `data.location` (`latitude`/`longitude` for nodes/arcs; `geoJsonValue` for geos) |
-
-> **Full reference:** `docs/cave_api_docs/cave_utils_api_utils_general.txt` — documents every prop type, variant, field, gradient system, and options structure. Read this before building any pane or map feature.
-
----
-
-## API Documentation Reference
-
-Full structured documentation for the CAVE API and all `cave_utils` modules lives in:
-
-```
-docs/cave_api_docs/
-```
-
-**Start here:**
-- `docs/cave_api_docs/API_README.txt` — index of all doc files
-- `docs/cave_api_docs/PROJECT_README.md` — `cave_utils` library overview (Validator, GroupsBuilder, Socket, etc.)
-
-**Consult the relevant `.txt` file when building any specific feature.** Each file documents the exact required and optional fields, types, and constraints for that part of the API. These files are the ground truth for what is valid — they take precedence over examples or README descriptions if there is a conflict.
-
-**Other useful docs:**
-- `docs/cave_api_docs/cave_utils_builders_groups.txt` — GroupsBuilder for chart data
-- `docs/cave_api_docs/cave_utils_socket.txt` — Socket methods
-- `docs/cave_api_docs/cave_utils_arguments.txt` — Arguments utility
-
----
-
-## Entry Point: `cave_api/api.py`
-
-This file is the single entry point. It must define or import `execute_command`. Three options are pre-configured (comment/uncomment to switch):
-
-- **Option 1 (default):** Example selector — browse all bundled examples from within the running app. Useful for exploration; not a coding template.
-- **Option 2:** `cave_api/src/app.py` — the minimal starting template for a real app. **Use this when building a custom app.**
+- **Option 1 (default):** Example selector — browse all bundled examples from within the running app. Not a coding template.
+- **Option 2:** `cave_api/src/app.py` — the minimal starting template. **Use this when building a custom app.**
 - **Option 3:** Load a specific example directly for quick reference or testing.
 
-**Recommended workflow:**
-1. Use Option 1 to explore examples and understand features
-2. Switch to Option 2 (`src/app.py`) to start building
-3. Keep examples intact in `cave_api/examples/` — they remain available for reference
+Recommended workflow: explore with Option 1 → switch to Option 2 to start building → keep `cave_api/examples/` intact for reference throughout.
 
----
+Write your app in `cave_api/src/` (add modules alongside `app.py` freely, e.g. `src/model.py`), keeping `api.py` itself as a thin router into `src/`. Put static data files in `cave_api/data/` and load them via `importlib.resources`:
 
-## Where to Write Custom App Code
-
-```
-cave_api/src/       ← your app lives here
-cave_api/data/      ← static data files (CSV, JSON, GeoJSON)
-pyproject.toml [project.optional-dependencies.api]    ← Python dependencies for your app
-```
-`cave_api/api.py` is a hardcoded entry point and must define `execute_command`. 
-    - The recommended pattern is to keep `cave_api/api.py` as a thin router that imports from other modules in `src/`.
-    - Currently `cave_api/api.py` imports from `cave_api/examples` but you will want to modify this as you begin working on your own app code.
-    - It is recommended to keep the `examples/` folder intact for reference as you build your app in `cave_api/src/`.
-`cave_api/src/app.py` is a starting template. Add modules alongside it freely (`src/model.py`, `src/charts.py`, etc.).
-
-**Loading data files:**
 ```python
 import json
 from importlib import resources
@@ -339,52 +81,19 @@ with open(data_folder.joinpath("my_data.json").__str__()) as f:
     data = json.load(f)
 ```
 
-**Adding dependencies:** edit `pyproject.toml` [project.optional-dependencies.api] and start (restart if running) your app with `cave run`.
+Add Python dependencies under `[project.optional-dependencies.api]` in `pyproject.toml`, then (re)start with `cave run` — see [cave-cli](.claude/skills/cave-cli/SKILL.md).
 
 ---
 
 ## Examples
 
-`cave_api/examples/` contains 20+ working examples. They are the best reference for how to construct any specific feature. Key examples:
-
-| Example | What it shows |
-|---|---|
-| `api_command.py` | Button → custom command → socket notification |
-| `api_command_export.py` | Export data to browser via command |
-| `map_nodes.py` / `map_arcs.py` / `map_geos.py` | Map feature types |
-| `chart_grouped_outputs_builder.py` | GroupsBuilder for chart data |
-| `general_props_all.py` | Every pane prop type (sliders, dropdowns, etc.) |
-| `pane_wall.py` / `pane_modal.py` | Pane layout variants |
-| `data_local_example.py` | Loading local CSV/JSON data |
-| `kitchen_sink.py` | Comprehensive multi-feature example |
-
-The `examples/selector/example_selector.py` file is infrastructure for the selector UI — it is not a coding example.
-
----
-
-## Linting
-
-Always use the Cave CLI formatter before committing:
-```
-cave prettify
-```
+`cave_api/examples/` contains 25+ working examples — the best reference for how to construct any specific feature. See the [examples](.claude/skills/examples/SKILL.md) skill for a categorized guide to picking the right one before writing new API code.
 
 ---
 
 ## Hot Reload
 
 Python file changes in `cave_api/` reload automatically while `cave run` is active. Restart required for: CSV/JSON data files, `pyproject.toml` changes, `Dockerfile` changes.
-
----
-
-## Debugging
-
-| Tool | How |
-|---|---|
-| Print statements | Output appears in the `cave run` terminal |
-| Live validation | Set `LIVE_API_VALIDATION_PRINT=true` in `.env` |
-| Manual validation | Run `cave test init.py` |
-| Browser console | `Ctrl+Shift+i` → Console tab (grey screen = frontend error) |
 
 ---
 
@@ -395,7 +104,7 @@ cave_api/             ← API project folder (your app logic lives here)
   api.py              ← entry point (Option 1/2/3)
   src/                ← custom app code goes here
     app.py            ← minimal starting template
-  examples/           ← 20+ reference examples (keep intact)
+  examples/           ← 25+ reference examples (keep intact)
     selector/         ← example browser UI (infrastructure, not a template)
   data/               ← static data files
 tests/                ← test files

--- a/docs/skills/add-feature/SKILL.md
+++ b/docs/skills/add-feature/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: add-feature
+description: Implement a new CAVE API feature (button, chart, map, slider, pane, etc.). Use when asked to add, change, or build out app functionality.
+---
+
+# Adding a Feature
+
+Default assumption: this is an API change in `cave_api/`, not a server change — see the layer table and escalation criteria at the top of `docs/DEVELOPMENT.md`.
+
+Workflow:
+
+1. Identify the relevant `session_data` top-level key(s) (`panes`, `mapFeatures`, `maps`, `groupedOutputs`, ...) — see [api-reference](../api-reference/SKILL.md) for the key table, the props schema, and how to find the matching doc in `docs/cave_api_docs/`.
+2. Find the closest existing example in `cave_api/examples/` and use it as a reference — don't build a prop schema from memory. See the [examples](../examples/SKILL.md) skill for a categorized guide to picking one.
+3. Implement in `cave_api/src/` (add a module alongside `app.py` if needed) and wire it into `cave_api/api.py`'s `execute_command` router.
+4. If the feature adds a new command, write a test first — see [add-test](../add-test/SKILL.md).
+5. Run [test](../test/SKILL.md) — at minimum `cave test init.py`; also `cave test examples.py` if you touched `cave_api/examples/`.
+6. If tests fail, diagnose whether the issue is the new code, a new test, or an existing test/example — fix and rerun.
+7. Once tests pass, run [lint](../lint/SKILL.md) (`cave prettify`).
+8. If something isn't rendering as expected, see [debug](../debug/SKILL.md).
+
+Report back with a summary of what changed and which tests were run.

--- a/docs/skills/add-test/SKILL.md
+++ b/docs/skills/add-test/SKILL.md
@@ -27,11 +27,17 @@ if __name__ == "__main__":
 
 Chain calls in order if a command depends on state set by a prior command (e.g. `init` populating the pane your command mutates).
 
+> [!TIP]
+> For advanced schema checks or ignoring specific keys during validation, see the [data-validation](../data-validation/SKILL.md) skill.
+
 Run it with `cave test test_<command_name>.py` — see [test](../test/SKILL.md).
 
 ### Replay-based regression tests
 
-To reproduce a bug or regression-test a real user session, capture a mutation log (CSV/JSON) into `tests/mutation_logs/`, then add a path assertion to `tests/replay.py`'s `test_replay` function using `Replay.get_path([...])`. The bundled example is `MutationLogExample.csv`. `test_all_logs()` runs `test_replay` against every file in `mutation_logs/` if you need to check all of them at once.
+To reproduce a bug or regression-test a real user session, capture a mutation log (CSV/JSON) into `tests/mutation_logs/`, then add a path assertion to `tests/replay.py`'s `test_replay` function using `Replay.get_path([...])`. The bundled example is `MutationLogExample.csv`. 
+
+> [!NOTE]
+> By default, running `cave test replay.py` only executes `test_replay` on `MutationLogExample.csv`. To run validation against every log file in the `mutation_logs/` folder at once, modify `tests/replay.py` to comment out the `test_replay(...)` call and uncomment `test_all_logs()`.
 
 ```python
 from utils.replay import Replay

--- a/docs/skills/add-test/SKILL.md
+++ b/docs/skills/add-test/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: add-test
+description: Add a test for a custom execute_command command, or extend replay/mutation-log regression testing. Use when asked to write a test or add test coverage for cave_api changes.
+---
+
+# Adding a Test
+
+`tests/init.py` covers the `init` command. If your app defines additional commands, add a dedicated test file.
+
+**Pattern** (`tests/test_<command_name>.py`):
+
+```python
+from cave_api.api import execute_command
+from cave_utils import Socket, Validator
+
+def test_<command_name>():
+    init_session_data = execute_command(session_data={}, socket=Socket(), command="init")
+    session_data = execute_command(session_data=init_session_data, socket=Socket(), command="<command_name>")
+
+    validator = Validator(session_data, ignore_keys=["meta"])
+    validator.log.print_logs()
+    assert len(validator.log.log) == 0
+
+if __name__ == "__main__":
+    test_<command_name>()
+```
+
+Chain calls in order if a command depends on state set by a prior command (e.g. `init` populating the pane your command mutates).
+
+Run it with `cave test test_<command_name>.py` — see [test](../test/SKILL.md).
+
+### Replay-based regression tests
+
+To reproduce a bug or regression-test a real user session, capture a mutation log (CSV/JSON) into `tests/mutation_logs/`, then add a path assertion to `tests/replay.py`'s `test_replay` function using `Replay.get_path([...])`. The bundled example is `MutationLogExample.csv`. `test_all_logs()` runs `test_replay` against every file in `mutation_logs/` if you need to check all of them at once.
+
+```python
+from utils.replay import Replay
+
+replay = Replay(mutation_log_file=log_file, print_on_invalid=True, raise_on_invalid=True)
+replay.advance(num_steps="all", validate_each_step=False, validate_on_completion=False)
+replay.validate()
+value = replay.get_path(["settings", "iconUrl"])
+```
+
+`advance()` options:
+
+| Option | Default | What it does |
+|---|---|---|
+| `num_steps` | `1` | Steps to advance, or `"all"` for every remaining event |
+| `validate_each_step` | `False` | Validate after every event — slower, but pinpoints the exact failing event |
+| `validate_on_completion` | `True` | Validate once after all steps complete |
+
+Run it with `cave test replay.py` — see [test](../test/SKILL.md).

--- a/docs/skills/api-reference/SKILL.md
+++ b/docs/skills/api-reference/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: api-reference
+description: Reference for the CAVE API surface — the execute_command function, session_data's 10 top-level keys, the props schema for panes/map features, and how to navigate the full field-level docs in docs/cave_api_docs/. Use when building or modifying any panes, map features, charts, or session_data structure, or when you need the exact required/optional fields for a specific API construct.
+---
+
+# CAVE API Reference
+
+## The API: One Function
+
+The entire CAVE API is a single Python function:
+
+```python
+def execute_command(session_data, socket, command="init", **kwargs):
+    ...
+    return session_data
+```
+
+| Parameter | Description |
+|---|---|
+| `session_data` | A plain dict representing the full app state. The frontend renders whatever is in here. |
+| `socket` | Sends notifications (`socket.notify("msg")`) or file exports (`socket.export("data:...")`) to the user. |
+| `command` | A string identifying what action to perform. Defaults to `"init"` on first load. |
+
+`execute_command` receives the current state, modifies it, and returns it. The framework handles routing, WebSockets, and rendering automatically.
+
+**Always handle `"init"`** — it runs on session start and must return the full initial state.
+
+**Standard command routing pattern:**
+```python
+def execute_command(session_data, socket, command="init", **kwargs):
+    if command == "init" or command == "reset":
+        return build_initial_state()
+    elif command == "run_model":
+        return update_state(session_data)
+    raise Exception(f"Command '{command}' not implemented")
+```
+
+## Session Data: 10 Top-Level Keys
+
+`session_data` is a plain dict. The top-level keys control every part of what the user sees. All are optional except `settings`.
+
+| Key | Purpose | Doc file |
+|---|---|---|
+| `settings` | App-wide settings (icon URL, sync, etc.). **Required.** | `cave_api_docs/cave_utils_api_settings.txt` |
+| `appBar` | Buttons and pane-launchers in the app bar | `cave_api_docs/cave_utils_api_appBar.txt` |
+| `pages` | Static info pages | `cave_api_docs/cave_utils_api_pages.txt` |
+| `panes` | Slide-out panels with input props (sliders, dropdowns, etc.) | `cave_api_docs/cave_utils_api_panes.txt` |
+| `maps` | Map views with viewport, projection, layers | `cave_api_docs/cave_utils_api_maps.txt` |
+| `mapFeatures` | Interactive items on maps (nodes, arcs, geos) | `cave_api_docs/cave_utils_api_mapFeatures.txt` |
+| `groupedOutputs` | Hierarchical chart/table data with grouping | `cave_api_docs/cave_utils_api_groupedOutputs.txt` |
+| `globalOutputs` | App-wide KPI values | `cave_api_docs/cave_utils_api_globalOutputs.txt` |
+| `draggables` | Draggable UI overlay elements | `cave_api_docs/cave_utils_api_draggables.txt` |
+| `extraKwargs` | Special server-level flags (e.g. `wipeExisting`) | `cave_api_docs/cave_utils_api_extraKwargs.txt` |
+
+**Minimum valid app:**
+```python
+return {
+    "settings": {
+        "iconUrl": "https://react-icons.mitcave.com/5.4.0"
+    }
+}
+```
+
+## Props: The Building Blocks for Panes and Map Features
+
+**Props** are UI component definitions. They appear in two places:
+
+- **Panes** — interactive controls (sliders, dropdowns, buttons, etc.) that users manipulate to drive your app
+- **Map features** — visualization schemas that control how nodes, arcs, and geos are colored, sized, and labeled
+
+Every prop is a dictionary with a `name` and a `type`. Everything else is optional.
+
+```python
+{
+    "my_slider": {
+        "name": "My Slider",
+        "type": "num",
+        "variant": "slider",
+        "minValue": 0,
+        "maxValue": 100,
+        "unit": "%",
+        "apiCommand": "run_model",   # fires execute_command with command="run_model"
+        "apiCommandKeys": ["panes"],  # only pass these session_data keys
+    }
+}
+```
+
+### Prop Types
+
+| Type | What it renders | Common variants |
+|---|---|---|
+| `"head"` | Section header / divider | `"column"`, `"row"`, `"icon"` |
+| `"num"` | Numeric input | `"field"`, `"slider"`, `"icon"`, `"incslider"` |
+| `"toggle"` | Boolean switch | — |
+| `"text"` | Text input | `"single"`, `"textarea"` |
+| `"selector"` | Selection control | `"dropdown"`, `"radio"`, `"checkbox"`, `"combobox"`, `"comboboxMulti"`, `"nested"` |
+| `"button"` | Clickable button (can fire `apiCommand`) | — |
+| `"date"` | Date/time picker | `"date"`, `"time"`, `"datetime"` |
+| `"media"` | Image or video display | `"picture"`, `"video"` |
+
+### Props in Panes
+
+Panes pair a `props` schema with a `values` dict. The keys must match.
+
+```python
+"panes": {
+    "data": {
+        "my_pane": {
+            "name": "Controls",
+            "props": {
+                "speed": {"name": "Speed", "type": "num", "variant": "slider", "minValue": 0, "maxValue": 10}
+            },
+            "values": {
+                "speed": 5   # current value, keyed by prop name
+            },
+            "layout": {"type": "grid", "numColumns": 1, "numRows": "auto"}
+        }
+    }
+}
+```
+
+### Props in Map Features (Nodes, Arcs, Geos)
+
+Map features use the same `props` schema, but values live in `data.valueLists` alongside location data.
+
+```python
+"mapFeatures": {
+    "data": {
+        "my_nodes": {
+            "type": "node",
+            "name": "Facilities",
+            "props": {
+                "capacity": {"name": "Capacity", "type": "num", "variant": "icon"}
+            },
+            "data": {
+                "location": {
+                    "latitude": [[42.3], [41.8]],   # one list per feature
+                    "longitude": [[-71.0], [-87.6]]
+                },
+                "valueLists": {
+                    "capacity": [500, 1200]           # one value per feature
+                }
+            }
+        }
+    }
+}
+```
+
+**Key distinction:**
+
+| | Panes | Map Features |
+|---|---|---|
+| Values key | `values` (flat dict, one value per prop) | `data.valueLists` (list of values, one per feature) |
+| Location | N/A | `data.location` (`latitude`/`longitude` for nodes/arcs; `geoJsonValue` for geos) |
+
+> **Full reference:** `docs/cave_api_docs/cave_utils_api_utils_general.txt` — documents every prop type, variant, field, gradient system, and options structure. Read this before building any pane or map feature.
+
+## Consulting `docs/cave_api_docs/` for field-level detail
+
+The tables above tell you *which* doc file covers a given `session_data` key — this section is how to use that folder itself.
+
+`docs/cave_api_docs/` is the full generated reference for `cave_utils`, the library that validates everything `execute_command` returns. It's plain text, one file per `cave_utils` module.
+
+**Start here:**
+1. `docs/cave_api_docs/README.txt` — index of every doc file in the folder, mapped to its `cave_utils` module path (e.g. `cave_utils.api.panes` → `./cave_utils_api_panes.txt`)
+2. `docs/cave_api_docs/PROJECT_README.md` — `cave_utils` library overview (Validator, GroupsBuilder, Socket, etc.) and a quick-start for validating `session_data` directly
+
+**Then go specific:** once you know which top-level `session_data` key you're building (from the table above), open its matching `.txt` file. Each one documents the exact required/optional fields, types, and constraints for that part of the API — **treat these as ground truth**, taking precedence over any example or README if they conflict.
+
+**Other useful docs in the same folder:**
+- `cave_utils_api_utils_general.txt` — every prop type, variant, field, gradient system, and options structure
+- `cave_utils_builders_groups.txt` — `GroupsBuilder`, for constructing `groupedOutputs` chart data
+- `cave_utils_socket.txt` — `Socket` methods (`notify`, `export`, ...)
+- `cave_utils_arguments.txt` — `Arguments` utility
+
+If a doc file doesn't answer the question, grep the folder — `README.txt`'s module names map directly to file names (dots become underscores, prefixed `cave_utils_`).
+
+These `.txt` files describe the schema abstractly (fields, types, constraints) — they aren't runnable code. For a working example that already assembles a given key or prop correctly, see the [examples](../examples/SKILL.md) skill.

--- a/docs/skills/cave-cli/SKILL.md
+++ b/docs/skills/cave-cli/SKILL.md
@@ -13,7 +13,7 @@ This app runs in Docker, managed entirely through the `cave` CLI — not `docker
 
 | Command | What it does |
 |---|---|
-| `cave run` | Build and run the CAVE app in the current directory. Add `ip:port` to host on LAN, `-it`/`--interactive` to drop into the entrypoint shell instead. See [run](../run/SKILL.md) for confirming it's actually up and driving it. |
+| `cave run` | Build and run the CAVE app. Add `ip:port` to host on LAN. Use `-it` to open bash inside the container, or `--all` to output raw logs instead of launching the TUI dashboard. See [run](../run/SKILL.md). |
 | `cave list` (`-a` for full names) | List running CAVE app containers |
 | `cave list-versions` (`cave lv`) | List available `cave_app` template versions (git tags); `--pattern` to filter, `--all` for the full history |
 | `cave doctor` | Check the health of the CAVE environment (Docker, dependencies, etc.) |
@@ -29,7 +29,7 @@ Every command below changes or removes local state (Docker containers/volumes, p
 | `cave reset` (`cave reset-db`) | Remove Docker containers and volumes, then rebuild from scratch | Wipes the local database and any container-local state |
 | `cave kill [app-name]` (`-a` for all) | Stop Docker containers for a CAVE app, or every running CAVE app | Stops a dev session that may be in use |
 | `cave purge <app-path>` | Remove a CAVE app and all its Docker resources | Irreversible |
-| `cave upgrade` | Upgrade the CAVE app template in the current directory to a different `--version` | Can rewrite or conflict with project files; touches `.env` unless `--skip-env-upgrade` |
+| `cave upgrade` | Upgrade the CAVE app template in the current directory to a different `--version` | Can rewrite or conflict with project files; touches `.env` unless `--skip-env-upgrade` is provided |
 | `cave sync --url <url>` | Merge files from another repository into this app | Can overwrite existing files |
 | `cave uninstall` | Remove the CAVE CLI itself | Removes the tool, not just app state |
 

--- a/docs/skills/cave-cli/SKILL.md
+++ b/docs/skills/cave-cli/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: cave-cli
+description: Use the cave CLI to manage this app's Docker environment — starting the dev server, resetting the database, listing/killing containers, upgrading the template, etc. Use when asked to run, start, stop, reset, or upgrade the app, or any other Docker-lifecycle task outside of testing (see test) or formatting (see lint).
+---
+
+# The `cave` CLI
+
+This app runs in Docker, managed entirely through the `cave` CLI — not `docker` directly. `cave test` and `cave prettify` have their own skills ([test](../test/SKILL.md), [lint](../lint/SKILL.md)); this skill covers everything else.
+
+**Flags and behavior can change between CLI versions.** The tables below are a map of what exists, not a substitute for checking. Before running an unfamiliar command, confirm its current flags with `cave <command> -h` (or `cave -h` for the full command list) rather than relying on memorized options.
+
+## Safe — routine dev loop
+
+| Command | What it does |
+|---|---|
+| `cave run` | Build and run the CAVE app in the current directory. Add `ip:port` to host on LAN, `-it`/`--interactive` to drop into the entrypoint shell instead. See [run](../run/SKILL.md) for confirming it's actually up and driving it. |
+| `cave list` (`-a` for full names) | List running CAVE app containers |
+| `cave list-versions` (`cave lv`) | List available `cave_app` template versions (git tags); `--pattern` to filter, `--all` for the full history |
+| `cave doctor` | Check the health of the CAVE environment (Docker, dependencies, etc.) |
+| `cave version` | Print CLI version info |
+| `cave theme <name>` | Set the CLI's own color theme (`dark`, `light`, `solarized`, `monokai`) — cosmetic, not app-related |
+
+## Destructive — always get explicit user confirmation before running
+
+Every command below changes or removes local state (Docker containers/volumes, project files, or the CLI itself). Don't run any of these because a step in your own workflow seems to call for it (e.g. "tests are failing, might as well reset the DB") — state what you want to run and why, and wait for a yes.
+
+| Command | What it does | Why it's risky |
+|---|---|---|
+| `cave reset` (`cave reset-db`) | Remove Docker containers and volumes, then rebuild from scratch | Wipes the local database and any container-local state |
+| `cave kill [app-name]` (`-a` for all) | Stop Docker containers for a CAVE app, or every running CAVE app | Stops a dev session that may be in use |
+| `cave purge <app-path>` | Remove a CAVE app and all its Docker resources | Irreversible |
+| `cave upgrade` | Upgrade the CAVE app template in the current directory to a different `--version` | Can rewrite or conflict with project files; touches `.env` unless `--skip-env-upgrade` |
+| `cave sync --url <url>` | Merge files from another repository into this app | Can overwrite existing files |
+| `cave uninstall` | Remove the CAVE CLI itself | Removes the tool, not just app state |
+
+## Setup-only — rarely relevant inside an existing app
+
+| Command | What it does |
+|---|---|
+| `cave create <app-name>` | Create a brand-new CAVE app from the template repository |
+| `cave update` | Update the CAVE CLI itself (not this app) |

--- a/docs/skills/data-building/SKILL.md
+++ b/docs/skills/data-building/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: data-building
+description: Build grouped charts and tabular hierarchies using GroupsBuilder and DateGroupsBuilder for groupedOutputs.
+---
+
+# Building Data Hierarchies for Charts
+
+The CAVE API uses a nested dictionary structure for `groupedOutputs` to populate charts and pivot tables. `cave_utils` simplifies constructing this schema from flat tabular data.
+
+## Using `GroupsBuilder`
+
+For hierarchical, non-temporal group relationships, use `GroupsBuilder` to build groupings and map data indices to group hierarchies:
+
+```python
+from cave_utils.builders.groups import GroupsBuilder
+
+# 1. Prepare flat relational data
+location_group_data = [
+    {"country": "USA", "state": "Michigan"},
+    {"country": "USA", "state": "Massachusetts"},
+    {"country": "Canada", "state": "Ontario"},
+]
+
+# 2. Instantiate GroupsBuilder
+location_group_builder = GroupsBuilder(
+    group_name="Locations",
+    group_data=location_group_data,
+    group_parents={"state": "country"}, # Defines hierarchy: state under country
+    group_names={
+        "country": "Countries",
+        "state": "States",
+    },
+)
+
+# 3. Serialize grouping schema for session_data['groupedOutputs']['groupings']
+location_groupings_dict = location_group_builder.serialize()
+
+# 4. Generate the corresponding mapping ID list for session_data['groupedOutputs']['data'][...]['groupLists']
+location_id_list = location_group_builder.get_id_list()
+```
+
+## Using `DateGroupsBuilder`
+
+For timeline or date-based groupings, use `DateGroupsBuilder` to automatically bucket and serialize date timelines:
+
+```python
+from cave_utils.builders.groups import DateGroupsBuilder
+
+# 1. Prepare date string ids
+date_ids = ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"]
+
+# 2. Instantiate DateGroupsBuilder
+date_builder = DateGroupsBuilder("Date", date_ids)
+
+# 3. Serialize date grouping schema for session_data['groupedOutputs']['groupings']
+date_groupings_dict = date_builder.serialize()
+```
+
+## Wiring into `session_data`
+
+The outputs of these builders are mapped to the `groupedOutputs` top-level key:
+
+```python
+"groupedOutputs": {
+    "order": {
+        "groupings": ["location", "date"],
+    },
+    "groupings": {
+        "location": location_group_builder.serialize(),
+        "date": date_builder.serialize(),
+    },
+    "data": {
+        "salesData": {
+            "order": {
+                "stats": ["sales"],
+            },
+            "stats": {
+                "sales": {
+                    "name": "Sales",
+                    "unit": "units",
+                },
+            },
+            # Map statistical values (usually pivoted into list format via pamda)
+            "valueLists": {
+                "sales": [95, 100, 100, 98],
+            },
+            # Map groupings to matching rows in valueLists
+            "groupLists": {
+                "location": location_group_builder.get_id_list(),
+                "date": date_ids, # Original date list
+            },
+        },
+    },
+}
+```
+

--- a/docs/skills/data-validation/SKILL.md
+++ b/docs/skills/data-validation/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: data-validation
+description: Run validation checks on session data dictionary objects using cave_utils Validator. Detect and fix schema errors before running the server.
+---
+
+# Data Validation with `cave_utils`
+
+CAVE can enforce strict schema validation for `session_data` outputs. Any validation failures appear as errors/warnings on the frontend or CLI.
+
+> [!TIP]
+> To run these validations as part of automated CI/CD checks or command regression testing, see [add-test](../add-test/SKILL.md).
+
+## Manual Validation in Tests
+
+To check a dictionary locally, use `cave_utils.Validator`:
+
+```python
+from cave_utils import Validator
+
+session_data = {
+    "settings": {"iconUrl": "https://example.com/icon.png"},
+    "panes": {...}
+}
+
+# Run the validator
+validator = Validator(session_data, ignore_keys=["meta"])
+
+# Print issues
+validator.log.print_logs()
+
+# Assert correctness
+assert len(validator.log.log) == 0, "Validation failed!"
+```
+
+## Running Live Validation on the Server
+
+To debug validation issues in real-time while using the app:
+
+1. Open `.env` in the root of your project directory.
+2. Set the environment variable:
+   ```env
+   LIVE_API_VALIDATION_PRINT=true
+   ```
+3. Run or restart the app: `cave run`
+4. The terminal will print detailed, structured JSON validation reports for every command interaction.
+
+For more details on monitoring these logs and debugging exceptions in real-time, see [debug](../debug/SKILL.md).
+
+

--- a/docs/skills/debug/SKILL.md
+++ b/docs/skills/debug/SKILL.md
@@ -1,15 +1,156 @@
 ---
 name: debug
-description: Debug a CAVE API app that isn't behaving as expected — validation errors, blank/grey screen, or unexpected session state. Use when asked to debug, troubleshoot, or investigate why something isn't working.
+description: Debug a CAVE API app that isn't behaving as expected — validation errors, blank/grey screen, unexpected session state, user reported errors, or live server tracebacks. Use when asked to debug, troubleshoot, or investigate why something isn't working.
 ---
 
-# Debugging
+# Debugging and Error Resolution
+
+This skill covers tracing, detecting, and resolving all types of errors (schema validation failures, live backend exceptions, database sync issues, and browser console errors) in CAVE.
+
+---
+
+## 1. Quick Debugging Reference
 
 | Tool | How |
 |---|---|
-| Print statements | Add `print(...)` in `cave_api/` — output appears in the `cave run` terminal (hot-reloads, no restart needed) |
-| Manual validation | `cave test init.py` — runs `Validator` against your `init` output and prints structured logs |
-| Live validation | Set `LIVE_API_VALIDATION_PRINT=true` in `.env`, then restart with `cave run` |
-| Browser console | `Ctrl+Shift+i` → Console tab — a grey/blank screen after `init` usually means a frontend error here, not a Python exception |
+| **Print statements** | Add `print(...)` in `cave_api/` — output appears in the `cave run` terminal (hot-reloads, no restart needed). |
+| **Raw logs** | Start the app with `cave run --all` (or `cave run -v`) to disable the TUI dashboard and print raw stdout/stderr directly (useful for full tracebacks). |
+| **Manual validation** | `cave test init.py` — runs `Validator` against your `init` output and prints structured logs. |
+| **Live validation** | Set `LIVE_API_VALIDATION_PRINT=true` in `.env`, then restart with `cave run` to see real-time updates. |
+| **Browser console** | `Ctrl+Shift+i` → Console tab — a grey/blank screen after `init` usually means a frontend error here, not a Python exception. |
 
-Start with `cave test init.py` for any structural/schema problem (missing required field, wrong type, bad prop reference) — the `Validator` log points at the exact path. Reach for the browser console only once `init.py` passes but the UI still looks wrong.
+---
+
+## 2. Detecting Live Server Errors
+
+When the CAVE application encounters an issue at runtime (e.g., when a user interacts with a widget or triggers an action), errors are logged directly to the server logs.
+
+### Checking Background Logs
+If the server is running in the background as a task:
+1. Locate the active task's log file in your agent's runtime data directory. This will be OS and agent-specific. To keep track of the log file, you may opt to pipe the logs to some project specific log file and investigate it from there. 
+2. Read the tail of the log file using `view_file` to find the **Errors** block:
+   ```text
+   Errors  (1 error)
+   ────────────────────────────────────────────────────────────────────────────
+   14:18:49          session_data=session_data, command=command, socket=socket…
+   14:18:49      )
+   14:18:49    File "/app/cave_api/examples/selector/example_selector.py", lin…
+   14:18:49      session_data = example_execute_command(session_data, socket, …
+   14:18:49    File "/app/cave_api/examples/kitchen_sink.py", line 2390, in ex…
+   14:18:49      raise Exception("Test Exception!")
+   14:18:49  Exception: Test Exception!
+   ────────────────────────────────────────────────────────────────────────────
+   ```
+
+### Running with Raw Logs (`cave run --all`)
+If background task logs are truncated or hard to read, stop any running containers and launch CAVE in raw log mode:
+```bash
+cave run --all
+```
+
+#### Key Details:
+* **Bypasses TUI Dashboard**: By default, `cave run` starts a terminal dashboard (TUI) summarizing container status. `--all` disables it, printing logs directly.
+* **Complete Tracebacks**: The dashboard TUI limits vertical space and truncates stack traces. `--all` outputs complete, scrollable python tracebacks, container builds, and django startup messages.
+* **Live Reload Monitoring**: Real-time output allows you to see exactly when Python files are modified and the Django development server hot-reloads.
+
+> [!NOTE]
+> Since `--all` streams stdout/stderr from all containers (app, database, cache) simultaneously, the output may interleave. To terminate the server, press `Ctrl+C` in the running terminal, or run `cave kill` in another terminal.
+
+---
+
+
+## 3. Step-by-Step Resolution Workflow
+
+```mermaid
+graph TD
+    A[Error Detected] --> B[Check server task logs / console output]
+    B --> C{Is there a traceback?}
+    C -- Yes --> D[Locate File, Line, and Exception type]
+    C -- No --> E[Check browser console Ctrl+Shift+I]
+    D --> F[Use view_file to inspect code block]
+    F --> G[Cross-reference API schemas]
+    G --> H[Apply code fix & verify hot-reload]
+    E --> I[Fix frontend configuration / props]
+    I --> H
+```
+
+1. **Isolate the Error**:
+   - Determine if the error is a **backend exception** (shown in python stack traces), a **schema validation error** (shown in `Validator` reports), or a **frontend crash** (blank screen, check browser dev tools console).
+2. **Locate the Problematic Code**:
+   - Find the file and line number at the bottom of the Python traceback (e.g., in [kitchen_sink.py](../../cave_api/examples/kitchen_sink.py)).
+   - Match the active `command` passed to `execute_command`.
+3. **Verify Schemas**:
+   - Run `cave test init.py` (see [test](../test/SKILL.md)) to make sure your baseline structure validates successfully.
+   - For real-time updates, verify that your changes conform to the correct property formats in the [api-reference](../api-reference/SKILL.md) skill.
+4. **Fix and Validate**:
+   - Edit the code. CAVE's server automatically hot-reloads Python changes, so you do not need to reboot the containers to verify most fixes.
+
+---
+
+## 4. Common Errors and Solutions
+
+| Error Sign / Message | Probable Cause | How to Fix |
+|---|---|---|
+| `Exception: Test Exception!` | Pressed the simulated "Outlined Button Example" | None. This is a built-in demo error triggered from [kitchen_sink.py](../../cave_api/examples/kitchen_sink.py). |
+| `KeyError: '...'` | Accessing a missing key in `session_data` (e.g. `session_data['panes']['data']`) | Check if the key exists using `.get()` or verify the initial structure in `init.py`. |
+| `AttributeError: 'NoneType' object has no attribute '...'` | Expecting an object but got `None` | Add safety checks (`if obj is not None:`) before reading properties. |
+| Page loads with blank/grey screen | Frontend JavaScript runtime crash | Open Chrome DevTools (`Ctrl+Shift+I`) → **Console** tab. Identify the React/JS error (often caused by invalid nested layout values or missing required props). Refer to the [layout-design](../layout-design/SKILL.md) skill. |
+| DB connection or migrations stuck | Postgres container sync issues | Run `cave reset` (Note: this is destructive and resets the DB state). |
+
+
+## 5. Proactive Debugging and Surfacing Bugs
+
+To detect hidden issues early or assist in tracing unknown bugs during development, use these programmatic techniques in your `cave_api/` handlers:
+
+### A. Defensive Coding & Context-Rich Exceptions
+Avoid allowing the app to fail silently or crash with generic `NoneType` or `KeyError` messages downstream. Raise descriptive exceptions that capture the current state:
+```python
+# Verify critical state assumptions
+if "my_key" not in session_data:
+    raise KeyError(
+        f"Missing critical key 'my_key' in session_data. "
+        f"Current keys: {list(session_data.keys())}"
+    )
+```
+
+### B. Inline Validation Checks
+If your command handler performs complex modifications to `session_data`, validate the result programmatically before returning it to the client:
+```python
+from cave_utils import Validator
+
+# Perform session modifications
+# ...
+
+# Run localized validation
+validator = Validator(session_data, ignore_keys=["meta"])
+if len(validator.log.log) > 0:
+    # Option 1: Print validation issues immediately to server logs
+    validator.log.print_logs()
+    
+    # Option 2: Notify the user/developer via a UI toast without crashing the backend
+    socket.notify(
+        message="A schema mismatch was detected in the session update. Check server logs.",
+        title="Schema Warning",
+        theme="warning"
+    )
+```
+
+### C. Live Logging and State Inspection
+Leverage hot-reloading by adding temporary debug prints. To trace execution flow and see parameters sent by the frontend:
+```python
+print(f"DEBUG: execute_command triggered with command={command}")
+print(f"DEBUG: Current session keys: {list(session_data.keys())}")
+```
+These prints will immediately output to the active server terminal (best viewed via `cave run --all`).
+
+### D. Mutation Log Capture
+If a bug only triggers after a specific sequence of user clicks:
+1. Capture the frontend mutation sequence logs under `tests/mutation_logs/`.
+2. Write a regression test in `tests/replay.py` to replay this exact sequence programmatically. Refer to the [add-test](../add-test/SKILL.md) skill.
+
+---
+
+
+## See Also
+- [test](../test/SKILL.md) — For running automated validation tests.
+- [data-validation](../data-validation/SKILL.md) — For validator logs and live schema print setups.

--- a/docs/skills/debug/SKILL.md
+++ b/docs/skills/debug/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: debug
+description: Debug a CAVE API app that isn't behaving as expected — validation errors, blank/grey screen, or unexpected session state. Use when asked to debug, troubleshoot, or investigate why something isn't working.
+---
+
+# Debugging
+
+| Tool | How |
+|---|---|
+| Print statements | Add `print(...)` in `cave_api/` — output appears in the `cave run` terminal (hot-reloads, no restart needed) |
+| Manual validation | `cave test init.py` — runs `Validator` against your `init` output and prints structured logs |
+| Live validation | Set `LIVE_API_VALIDATION_PRINT=true` in `.env`, then restart with `cave run` |
+| Browser console | `Ctrl+Shift+i` → Console tab — a grey/blank screen after `init` usually means a frontend error here, not a Python exception |
+
+Start with `cave test init.py` for any structural/schema problem (missing required field, wrong type, bad prop reference) — the `Validator` log points at the exact path. Reach for the browser console only once `init.py` passes but the UI still looks wrong.

--- a/docs/skills/examples/SKILL.md
+++ b/docs/skills/examples/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: examples
+description: Pick the right reference example from cave_api/examples/ before implementing a feature. Use when adding or modifying panes, modals, maps, map features, charts, api commands, or data loading — to find the closest validated pattern instead of building a prop schema from memory.
+---
+
+# Picking an Example
+
+`cave_api/examples/` contains 25+ working, validated `execute_command` implementations. Before writing new API code, find the closest match below, open it, and adapt it — copying a working pattern is faster and safer than building a prop schema from memory.
+
+If nothing here fits, grep the folder for the top-level `session_data` key or prop `type`/`variant` you need (`grep -rl '"type": "arc"' cave_api/examples/`) — there's likely a closer match than you think.
+
+### Maps & map features
+
+| Example | What it shows |
+|---|---|
+| `map.py` | Baseline map: projections, default viewport |
+| `map_customized.py` | Custom map styles (including custom Mapbox GL style URLs) |
+| `map_nodes.py` / `map_arcs.py` / `map_geos.py` | The three map feature types, one per file |
+| `map_node_animations.py` | Animated nodes |
+| `map_zindex.py` | Layering order between nodes, arcs, and geos |
+| `map_large_dataset.py` | Rendering a large number of map features performantly |
+| `map_custom_tiles.py` | Custom background image tiles with `CustomCoordinateSystem` |
+
+### Panes & modals
+
+| Example | What it shows |
+|---|---|
+| `pane_wall.py` | A pane launched from the app bar |
+| `pane_modal.py` | A modal launched from the app bar |
+| `general_props_all.py` | Every prop type and variant in one pane — the canonical prop reference |
+| `general_props_all_advanced.py` | More advanced prop configurations, including loading markdown help content from `content/help/` |
+
+### Charts & outputs
+
+| Example | What it shows |
+|---|---|
+| `chart_grouped_outputs.py` | Basic `groupedOutputs` chart page |
+| `chart_grouped_outputs_date.py` | `groupedOutputs` grouped by date |
+| `chart_grouped_outputs_builder.py` | `GroupsBuilder` for constructing group hierarchies from flat data |
+| `chart_grouped_outputs_builder_date.py` | `DateGroupsBuilder`, the date-based counterpart |
+| `chart_global_outputs.py` | App-wide KPI-style `globalOutputs` |
+| `3_by_3_charts_grouped_outputs.py` | Complex multi-chart layout using `pamda` to project/pivot data before feeding `GroupsBuilder` |
+
+### API commands & data loading
+
+| Example | What it shows |
+|---|---|
+| `api_command.py` | Button → custom command → `socket.notify()` |
+| `api_command_export.py` | Exporting data to the browser via a command |
+| `data_local_example.py` | Loading a local CSV/JSON file from `cave_api/data/` |
+| `data_external_example.py` | Calling an external API (US Census Bureau) from inside `execute_command` |
+
+### Settings & everything at once
+
+| Example | What it shows |
+|---|---|
+| `general_settings_sync.py` | De-syncing pane state from the server (most state syncs by default) |
+| `kitchen_sink.py` | Large, comprehensive example touching most features at once — good for seeing features interact, harder to isolate a single pattern from than the files above |
+
+### Supplementary examples: `other_examples/`
+
+Not part of the curated set above and not shown in the in-app example browser, but still real working code — check here if the main set doesn't cover your case:
+
+| Path | What it shows |
+|---|---|
+| `other_examples/future/chart_grouped_outputs_filter.py` | Filtering on `groupedOutputs` |
+| `other_examples/future/map_nodes_filter.py` | Filtering a node map feature |
+| `other_examples/future/map_feature_all_3D.py` | 3D map features |
+| `other_examples/map_feature_local_geojson/` | Loading a local GeoJSON file for a map feature, including a geojson-generation helper script |
+| `other_examples/map_many_nodes.py` | A map variant with a very large node count |
+
+### Not examples — infrastructure
+
+- `examples/selector/example_selector.py` — serves the in-app example browser UI. Not a pattern to copy.
+- `examples/content/` — static markdown/help assets referenced by `general_props_all_advanced.py`.
+
+### After copying a pattern
+
+Cross-check the specific fields you changed against the [api-reference](../api-reference/SKILL.md) skill (or the matching file in `docs/cave_api_docs/`) — examples show *a* valid configuration, not every valid field. If you edit a file inside `cave_api/examples/` itself, run `cave test examples.py` — see the [test](../test/SKILL.md) skill.

--- a/docs/skills/layout-design/SKILL.md
+++ b/docs/skills/layout-design/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: layout-design
+description: Design and structure app layouts (grids, rows, columns, and containers) for custom panes and draggables using layout specifications.
+---
+
+# Designing Layouts in CAVE
+
+CAVE custom panes and draggable elements rely on a structured layout configuration to position interactive components (props).
+
+## Layout Structure
+
+Layout definitions reside inside a pane or draggable definition under the `layout` key:
+
+```python
+"layout": {
+    "type": "grid",
+    "numColumns": 2,      # Renders a 2-column grid
+    "numRows": "auto",    # Dynamically sizes rows
+    "data": {
+        "item_1": {"type": "item", "itemId": "prop_a", "column": 1, "row": 1},
+        "item_2": {"type": "item", "itemId": "prop_b", "column": 2, "row": 1},
+        "item_3": {"type": "item", "itemId": "prop_c", "column": 1, "row": 2, "columnSpan": 2}
+    }
+}
+```
+
+### Key Parameters:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `type` | `str` | Must be either `"grid"` (container) or `"item"` (leaf containing a prop). |
+| `numColumns` | `str` \| `int` | Number of columns in a grid. Defaults to `"auto"`. |
+| `numRows` | `str` \| `int` | Number of rows in a grid. Defaults to `"auto"`. |
+| `itemId` | `str` | Used for `type="item"` to map layout to a prop key in the `props` dictionary. |
+| `column` / `row` | `int` | 1-based index positioning the item inside its parent grid. |
+| `style` | `dict` | CSS escape hatch (e.g. `{"padding": "10px"}`). |
+
+## Common Layout Variants
+
+1. **Simple Stack (Single Column):** Set `numColumns: 1` and `numRows: "auto"`. Items will stack vertically.
+2. **Grid Matrix:** Explicitly coordinate items by assigning distinct `column` and `row` indices.
+3. **Escaping Borders with Containers:** Customize `container` in the prop definitions:
+   - `"vertical"`: Title on top, wrapped in an embossed box (default).
+   - `"horizontal"`: Title on left, component on right.
+   - `"none"`: Renders component directly without title/borders.
+
+## Nested Grids (Subgrids)
+
+Since a grid layout element can contain other layout elements, you can nest layout definitions to create complex dashboard structures. 
+
+To define a nested grid, set the child element's `"type"` to `"grid"` and include a nested `"data"` block.
+
+### Example: Nested Grid Definition
+
+```python
+"layout": {
+    "type": "grid",
+    "numColumns": 2,
+    "numRows": 1,
+    "data": {
+        "left_item": {
+            "type": "item",
+            "itemId": "primary_toggle",
+            "column": 1,
+            "row": 1
+        },
+        "right_grid_column": {
+            "type": "grid",
+            "column": 2,
+            "row": 1,
+            "numColumns": 1,
+            "numRows": 2,
+            "data": {
+                "top_subitem": {
+                    "type": "item",
+                    "itemId": "numeric_input_1",
+                    "column": 1,
+                    "row": 1
+                },
+                "bottom_subitem": {
+                    "type": "item",
+                    "itemId": "numeric_input_2",
+                    "column": 1,
+                    "row": 2
+                }
+            }
+        }
+    }
+}
+```
+
+In this example, the main layout is split into two columns. The left column contains a single item (`primary_toggle`), while the right column contains a nested grid structure that arranges two sub-items (`numeric_input_1` and `numeric_input_2`) in a vertical stack.
+

--- a/docs/skills/lint/SKILL.md
+++ b/docs/skills/lint/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: lint
+description: Format cave_api/, cave_app/, and cave_core/ with autoflake + black via the cave CLI. Use when asked to format, lint, clean up style, prettify, or before committing Python changes.
+---
+
+# Formatting
+
+Run:
+
+```
+cave prettify
+```
+
+This runs autoflake (strips unused imports) followed by black over `cave_api/`, `cave_app/`, and `cave_core/` (see `utils/prettify.sh`). `cave_api/api.py` is excluded from unused-import stripping — it intentionally imports example/template modules that may not all be referenced at once (see the Option 1/2/3 entry-point pattern in `docs/DEVELOPMENT.md`).
+
+Run it before committing any Python changes. Rerun the relevant test afterward (`cave test init.py` at minimum) to confirm nothing broke. If a test fails only after formatting, flag it to the user and stop — wait for further instructions before proceeding.

--- a/docs/skills/release/SKILL.md
+++ b/docs/skills/release/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: release
+description: Release checklist for the cave_app template repo (version bump, tag, publish). Owner-only — do not execute; use this when asked to cut a release, bump the version, or publish a new cave_app version, to explain why you're stopping instead.
+---
+
+# Release Process — Owner Only
+
+**DO NOT RUN A RELEASE CYCLE.** Do not bump `version` in `pyproject.toml`, create a git tag, or push a release. This repo (`mit-cave/cave_app`) is the template that `cave create`, `cave upgrade`, and `cave list-versions` pull from via git tags — a bad release breaks every downstream app that upgrades into it. If asked to cut a release, flag it to the user and stop — don't execute any of the steps below yourself.
+
+For reference, the shape of the process (owner executes manually):
+
+1. Bump `version` in `pyproject.toml`
+2. Run `cave prettify`
+3. Run the full test suite — `cave test init.py`, `cave test examples.py`, `cave test database.py`, `cave test replay.py` — all must pass
+4. Tag the release (matching the scheme `cave list-versions` / `cave upgrade --version` expect) and push the tag
+5. Confirm the new version is visible via `cave list-versions`

--- a/docs/skills/run/SKILL.md
+++ b/docs/skills/run/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: run
+description: Launch the CAVE app in Docker via `cave run`, confirm it's actually serving, and open/drive it in the browser at localhost:8000/cave/. Use when asked to run, start, launch, or verify the app is working end-to-end — not just `cave test`.
+---
+
+# Running the CAVE App
+
+`cave run` builds and starts the app's Docker containers (Postgres, the Django/Daphne ASGI server, etc.) — see [cave-cli](../cave-cli/SKILL.md) for the full command reference. This skill is specifically about getting a running instance you can look at and verify.
+
+## 1. Start it
+
+`cave run` is a long-running foreground process — run it in the background and watch its output rather than blocking on it:
+
+```
+cave run
+```
+
+First boot runs `manage.py check`, ensures Postgres is up, and applies DB setup/migrations — this can take noticeably longer than subsequent starts.
+
+To run on a specific LAN `ip:port` instead of localhost (uses a self-signed SSL cert — see `utils/lan_hosting/readme.md`):
+```
+cave run <ip>:<port>
+```
+
+## 2. Confirm it's actually serving
+
+Poll the base URL rather than trusting the log stream — the container can report as running before Django finishes its startup checks. There's a real loading period on first boot (waiting for Postgres, `manage.py check`, DB migrations) — give it room, but cap how long you wait:
+
+```
+timeout 30 bash -c 'until curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/cave/ | grep -q 200; do sleep 3; done'
+```
+
+If it never comes up within that window, don't keep waiting or retry silently — notify the user that startup is stuck (include whatever the logs show) and run `cave kill` to stop it rather than leaving a hung container running.
+
+## 3. Open and drive it
+
+The app lives at `http://localhost:8000/cave/` — Chrome is the only fully supported browser.
+
+- Most of the app requires being logged in. The default admin's credentials are in this project's `.env` (`DJANGO_ADMIN_USERNAME` / `DJANGO_ADMIN_PASSWORD`) — treat `.env` as a secrets file: look up a specific key if you need it, don't cat/print/paste its full contents into chat or logs.
+- After login, click the app-page icon, then the examples switcher (three sliders, top left) to browse the bundled `cave_api/examples/` — see the [examples](../examples/SKILL.md) skill.
+- A blank/grey screen after load means a frontend error, not necessarily a Python one — see the [debug](../debug/SKILL.md) skill (start with the browser console, `Ctrl+Shift+i`).
+
+`cave test init.py` (see [test](../test/SKILL.md)) validates your `execute_command` output headlessly and is faster for iterating on API changes. Reach for a real run when you need to see the rendered UI itself, not just validate the schema.
+
+## 4. Stop it
+
+`cave kill` stops the containers — it's in the destructive tier of [cave-cli](../cave-cli/SKILL.md), so confirm with the user before running it. The one exception is the stuck-startup case in step 2: there, notifying the user *is* the confirmation — kill it right after telling them, don't leave a hung container running while waiting on a reply.

--- a/docs/skills/test/SKILL.md
+++ b/docs/skills/test/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: test
+description: Run the cave_api test suite via the cave CLI (cave test <file>). Use when asked to run tests, verify an API change, or check that init/examples/replay logic is valid.
+---
+
+# Running Tests
+
+Tests live in `tests/`. Do not run them directly with `python` — always go through the `cave` CLI, which runs them inside the app's Docker container:
+
+```
+cave test <test_file.py>
+```
+
+### Default available test files
+
+| File | Purpose | When to run |
+|---|---|---|
+| `init.py` | Calls `execute_command` with `command="init"` and validates the output. **Primary test.** | After any `cave_api/` change |
+| `examples.py` | Runs `init` on every example under `cave_api/examples/` and validates each. | After touching any file in `cave_api/examples/` |
+| `database.py` | Checks DB state (a user exists and has a personal team). Server-layer only. | After Django model or auth changes |
+| `replay.py` | Replays a recorded mutation log (`tests/mutation_logs/`) through `execute_command` and validates the resulting session state. | After capturing a mutation log, or to regression-test a specific session |
+
+```
+cave test init.py          # validate your app's init command (most common)
+cave test examples.py      # validate all bundled examples
+cave test database.py      # server-layer DB check
+cave test replay.py        # replay a mutation log and validate session state
+```
+
+### Standard pattern
+
+`tests/init.py` ships configured to match whatever you are seeing in your live application:
+
+```python
+from cave_api.api import execute_command
+from cave_utils import Socket, Validator
+
+def test_init():
+    init_session_data = execute_command(session_data={}, socket=Socket(), command="init")
+
+    validator = Validator(init_session_data, ignore_keys=["meta"])
+    validator.log.print_logs()
+    assert len(validator.log.log) == 0
+
+if __name__ == "__main__":
+    test_init()
+```
+
+For command-specific tests beyond `init`, or extending replay coverage, see [add-test](../add-test/SKILL.md).

--- a/docs/skills/test/SKILL.md
+++ b/docs/skills/test/SKILL.md
@@ -5,7 +5,10 @@ description: Run the cave_api test suite via the cave CLI (cave test <file>). Us
 
 # Running Tests
 
-Tests live in `tests/`. Do not run them directly with `python` — always go through the `cave` CLI, which runs them inside the app's Docker container:
+Tests live in `tests/`. Do not run them directly with `python` — always go through the `cave` CLI, which runs them inside the app's Docker container.
+
+> [!IMPORTANT]
+> Running `cave test` without specifying a test file will result in a `Test not found` error. You must always pass a test file.
 
 ```
 cave test <test_file.py>


### PR DESCRIPTION
Migrate from one development.md to a skills based approach

Add skills for:

- add-feature
- add-test
- api-reference
- cave-cli
- data-building
- debug
- examples
- layout-design
- lint
- release
- run
- test

Drop gemini support
Add antigravity support